### PR TITLE
Provider: clear global caches at each provider config

### DIFF
--- a/internal/locks/lock.go
+++ b/internal/locks/lock.go
@@ -40,3 +40,7 @@ func UnlockMultipleByName(names *[]string, resourceType string) {
 		UnlockByName(name, resourceType)
 	}
 }
+
+func Clear() {
+	armMutexKV = newMutexKV()
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -18,8 +19,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/resourceproviders"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	appconfigurationClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/client"
+	keyvaultClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
+	managedhsmClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/client"
+	storageClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/client"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
@@ -356,6 +362,15 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 
 func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		// Rest global caches
+		log.Printf("[DEBUG] Clear gloabl caches")
+		locks.Clear()
+		resourceproviders.ClearCache()
+		appconfigurationClient.ClearCache()
+		keyvaultClient.ClearCache()
+		managedhsmClient.ClearCache()
+		storageClient.ClearCache()
+
 		var auxTenants []string
 		if v, ok := d.Get("auxiliary_tenant_ids").([]interface{}); ok && len(v) > 0 {
 			auxTenants = *utils.ExpandStringSlice(v)

--- a/internal/services/appconfiguration/client/helpers.go
+++ b/internal/services/appconfiguration/client/helpers.go
@@ -21,6 +21,11 @@ var (
 	lock                    = map[string]*sync.RWMutex{}
 )
 
+func ClearCache() {
+	configurationStoreCache = map[string]ConfigurationStoreDetails{}
+	lock = map[string]*sync.RWMutex{}
+}
+
 type ConfigurationStoreDetails struct {
 	configurationStoreId string
 	dataPlaneEndpoint    string

--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -21,6 +21,11 @@ var (
 	lock           = map[string]*sync.RWMutex{}
 )
 
+func ClearCache() {
+	keyVaultsCache = map[string]keyVaultDetails{}
+	lock = map[string]*sync.RWMutex{}
+}
+
 type keyVaultDetails struct {
 	keyVaultId       string
 	dataPlaneBaseUri string

--- a/internal/services/managedhsm/client/helpers.go
+++ b/internal/services/managedhsm/client/helpers.go
@@ -21,6 +21,11 @@ var (
 	lock     = map[string]*sync.RWMutex{}
 )
 
+func ClearCache() {
+	cache = map[string]managedHSMDetail{}
+	lock = map[string]*sync.RWMutex{}
+}
+
 type managedHSMDetail struct {
 	managedHSMId     managedhsms.ManagedHSMId
 	dataPlaneBaseUri string

--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -22,6 +22,10 @@ var (
 	credentialsLock = sync.RWMutex{}
 )
 
+func ClearCache() {
+	storageAccountsCache = map[string]accountDetails{}
+}
+
 type EndpointType string
 
 const (


### PR DESCRIPTION
Clear global caches at each provider config. These global caches are detected via a separate tool.

Question: Is there anything else need to clean up between each configuration?